### PR TITLE
Make mod game-agnostic

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -70,9 +70,12 @@ local function get_river_existence(x,z,rivernoise)
 end
 
 
-local c_stone = minetest.get_content_id("default:stone")
-local c_water = minetest.get_content_id("default:water_source")
-local c_rwater = minetest.get_content_id("default:river_water_source")
+local c_stone, c_water, c_rwater
+minetest.register_on_mods_loaded(function()
+    c_stone = minetest.get_content_id("mapgen_stone")
+    c_water = minetest.get_content_id("mapgen_water_source")
+    c_rwater = minetest.get_content_id("mapgen_river_water_source")
+end)
 
 local water_level = 0
 

--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,2 @@
 name=the_confluence
-depends=luamap,default,biomegen
+depends=luamap,biomegen


### PR DESCRIPTION
Makes mod game-agnostic by dehardcoding MTG node names and replacing them with mapgen aliases